### PR TITLE
Tightens the logic getting the current version to avoid multiple returns

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           set -eu -o pipefail
           RELEASE=false
           PRIOR_VERSION=$(git describe --abbrev=0 --tags || true)
-          RELEASE_VERSION=$(grep current_version .bumpversion.cfg | sed 's/^.*= //' )
+          RELEASE_VERSION=$(grep -E "current_version\s*=" .bumpversion.cfg | sed 's/^.*= //' )
           if [[ "$PRIOR_VERSION" != "$RELEASE_VERSION" ]]; then RELEASE=true; fi
           echo "condition=${RELEASE}"
           echo "version=${RELEASE_VERSION}"


### PR DESCRIPTION
For example, taking the .bumpversion.cfg from [slack-aws-notifier](https://github.com/plus3it/terraform-aws-slack-notifier/blob/master/.bumpversion.cfg):

```
❯ grep "current_version" .bumpversion.cfg
current_version = 3.2.0
search = "version": "{current_version}"
search = "version": "{current_version}"
```

vs the new logic:

```
❯ grep -E "current_version\s*=" .bumpversion.cfg
current_version = 3.2.0
```

Will fix release failures such as this one: https://github.com/plus3it/terraform-aws-slack-notifier/actions/runs/5323905775/jobs/9642557972