### PR TITLE
Checks out the project to release so clean:false works in release action

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.1
+current_version = 1.8.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
       release-condition: ${{ steps.release.outputs.release-condition }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout project for release
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout release action
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: plus3it/actions-workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [1.8.2](https://github.com/plus3it/actions-workflows/releases/tag/1.8.2)
+
+**Released**: 2025.06.23
+
+*   Retrieves the release action so it is available to reusable workflows
+
 ### [1.8.1](https://github.com/plus3it/actions-workflows/releases/tag/1.8.1)
 
 **Released**: 2025.06.13


### PR DESCRIPTION
Fixes the error noted in the spel release workflow: https://github.com/plus3it/spel/actions/runs/15779939792/job/44482938682

1. "Checkout" step checked out the _actions-workflow_ project ✔️ 
2. "Move release action" made the action file local to the spel working directory ✔️ 
3. "Release" executes the release action, which has its own checkout action (necessary to retrieve and compare tags), but since it wasn't in a git repo (since the _spel_ project _was not_ checked out previously), the checkout action deleted the project contents (`Deleting the contents of '/home/runner/work/spel/spel'`), which also deleted the local release action from above ❌ 
4. "Post Release" fails because the local action is no longer present ❌ 

This PR resolves the problem by first checking out the project to be released (spel, in the example above). This way, when the second checkout runs in the release action, it sees it is already a git repo, and it honors the `clean: false` flag to skip deleting the project contents.